### PR TITLE
Change errno header from sys/errno.h to errno.h

### DIFF
--- a/delve.c
+++ b/delve.c
@@ -20,6 +20,7 @@
 ================================================================================
 */
 /*============================================================================*/
+#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdarg.h>
@@ -27,7 +28,6 @@
 
 #include <sys/types.h>
 #include <sys/socket.h>
-#include <sys/errno.h>
 #include <netdb.h>
 #include <unistd.h>
 


### PR DESCRIPTION
The errno variable is found in errno.h, not sys/errno.h (at least on OpenBSD).